### PR TITLE
fix: add order by to make values be picked up

### DIFF
--- a/openelevationservice/server/api/querybuilder.py
+++ b/openelevationservice/server/api/querybuilder.py
@@ -123,6 +123,7 @@ def point_elevation(geometry, format_out, dataset):
                             .query(query_point2d.c.geom,
                                    ST_Value(Model.rast, query_point2d.c.geom).label('z')) \
                             .filter(ST_Intersects(Model.rast, query_point2d.c.geom)) \
+                            .order_by(ST_Value(Model.rast, query_point2d.c.geom).asc()) \
                             .subquery().alias('getelevation')
         
         if format_out == 'geojson': 


### PR DESCRIPTION
The querys `ST_Value` returns a table with one col and multiple rows. A row for each raster tile that `ST_Intersects` returns true for. Previously, all except one value at tile borders were `null`. The valid value was at the bottom of the table returned by `ST_Value`. Only the topmost point is picked up by the application. The `order by` now makes sure that the valid value is at the top of the table in order to be picked up.